### PR TITLE
Rename global resources

### DIFF
--- a/agent-composer/transform/src/app.js
+++ b/agent-composer/transform/src/app.js
@@ -128,7 +128,7 @@ exports.handler = async (event) => {
                         }
                     ]
                 },
-                Path: '/BuildkiteAgentExecution/',
+                Path: templateParameterValues['ExecutionRolePrefix'] || '/BuildkiteAgentExecution/',
                 ManagedPolicyArns: [
                     'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy',
                 ],
@@ -180,7 +180,7 @@ exports.handler = async (event) => {
                             }
                         ]
                     },
-                    Path: '/BuildkiteAgentTask/',
+                    Path: templateParameterValues['TaskRolePrefix'] || '/BuildkiteAgentTask/',
                     Policies: []
                 },
             };

--- a/agent-scheduler/src/handlers/buildkite-run-task.js
+++ b/agent-scheduler/src/handlers/buildkite-run-task.js
@@ -339,7 +339,7 @@ async function getEcsRunTaskParamsForJob(cluster, job) {
 
     let taskRole = getAgentQueryRule("task-role", job.agent_query_rules);
     if (taskRole != undefined) {
-        let taskRoleArn = `${process.env.TASK_ROLE_ARN_PREFIX}/${taskRole}`;
+        let taskRoleArn = `${process.env.TASK_ROLE_ARN_PREFIX}${taskRole}`;
 
         console.log(`fn=getEcsRunTaskParamsForJob taskRoleArn=${taskRoleArn}`);
         taskParams.overrides.taskRoleArn = taskRoleArn;

--- a/agent-scheduler/template.yml
+++ b/agent-scheduler/template.yml
@@ -199,7 +199,7 @@ Resources:
                 Action:
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/buildkite/agent-token
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteAgentTokenParameterPath}
               - Effect: Allow
                 Action: kms:Decrypt
                 Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/aws/ssm

--- a/agent-scheduler/template.yml
+++ b/agent-scheduler/template.yml
@@ -55,6 +55,14 @@ Parameters:
     Type: String
     Default: ''
     Description: (Optional) API Gateway Stage ARN for an iam-ssh-agent backend.
+  ExecutionRolePrefix:
+    Type: String
+    Default: '/BuildkiteAgentExecution/'
+    AllowedPattern: (\u002F[\u0021-\u007F]+\u002F)
+  TaskRolePrefix:
+    Type: String
+    Default: '/BuildkiteAgentTask/'
+    AllowedPattern: (\u002F[\u0021-\u007F]+\u002F)
 
 Conditions:
   IncludeSshAgent: !Not [ !Equals [  !Ref SshAgentBackend, '' ] ]
@@ -129,15 +137,15 @@ Resources:
           - Effect: Allow
             Action: iam:PassRole
             Resource:
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/BuildkiteAgentExecution/*
-              - !Sub arn:aws:iam::${AWS::AccountId}:role/BuildkiteAgentTask/*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role${ExecutionRolePrefix}*
+              - !Sub arn:aws:iam::${AWS::AccountId}:role${TaskRolePrefix}*
           Version: "2012-10-17"
       Environment:
         Variables:
           ECS_CLUSTER_NAME: !Ref EcsClusterName
           VPC_SUBNETS: !Join [ ',', !Ref VpcSubnetIds ]
           LAUNCH_TYPE: !Ref EcsLaunchType
-          TASK_ROLE_ARN_PREFIX: !Sub "arn:aws:iam::${AWS::AccountId}:role/BuildkiteAgentTask"
+          TASK_ROLE_ARN_PREFIX: !Sub "arn:aws:iam::${AWS::AccountId}:role${TaskRolePrefix}"
           DEFAULT_EXECUTION_ROLE_ARN: !GetAtt DefaultExecutionRole.Arn
           BUILDKITE_AGENT_TOKEN_PARAMETER_PATH: !Ref BuildkiteAgentTokenParameterPath
           IAM_SSH_AGENT_BACKEND_URL:
@@ -188,7 +196,7 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
-      Path: /BuildkiteAgentExecution/
+      Path: !Ref ExecutionRolePrefix
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
       Policies:

--- a/agent-scheduler/template.yml
+++ b/agent-scheduler/template.yml
@@ -216,7 +216,7 @@ Resources:
   BuildkiteEventsLog:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: /aws/events/Buildkite
+      LogGroupName: !Sub /aws/events/buildkite/${AWS::StackName}
       RetentionInDays: 1
 
   BuildkiteEventsLogRule:


### PR DESCRIPTION
Rename the global resources for CloudWatch Logs and IAM paths.

Fixes #13 
Fixes #18 