### PR TITLE
Reads the buildkite-agent token parameter path from parameters

### DIFF
--- a/agent-composer/transform/src/app.js
+++ b/agent-composer/transform/src/app.js
@@ -18,11 +18,6 @@ exports.handler = async (event) => {
 
     console.log(`doing processing...`);
 
-    let Globals = fragment.Globals || {};
-    delete fragment.Globals;
-
-    let GlobalsTaskDefinition = Globals.TaskDefinition || {};
-
     let resources = {};
 
     for (let resourceName in fragment['Resources']) {
@@ -84,7 +79,7 @@ exports.handler = async (event) => {
             },
         };
 
-        let BuildkiteAgentTokenParameterPath = GlobalsTaskDefinition.BuildkiteAgentTokenParameterPath || '/buildkite/agent-token';
+        let BuildkiteAgentTokenParameterPath = templateParameterValues['BuildkiteAgentTokenParameterPath'] || '/buildkite-agent/token';
 
         var containerSecrets = [
             {


### PR DESCRIPTION
This allows passing a dynamic path from a parent stack, where the custom serverless transform like Globals doesn't.