### PR TITLE
Update remaining docker and github references

### DIFF
--- a/agent-composer/README.md
+++ b/agent-composer/README.md
@@ -64,10 +64,9 @@ With that image in hand, it is possible to schedule a container which simply
 (or platform equivalent) to bring the `buildkite` volume in to another
 container. This is possible in both ECS Tasks and Kubernetes Pods.
 
-A ready made agent sidecar image is available on Docker Hub
-[`keithduncan/buildkite-sidecar`](https://hub.docker.com/r/keithduncan/buildkite-sidecar),
-though it is also possible to build your own. The source for this image is
-available on [GitHub](https://github.com/buildkite/buildkite-sidecar).
+A ready made agent sidecar image is available on Docker Hub in the
+[`buildkite/agent`](https://hub.docker.com/r/buildkite/agent) repository. The 
+sidecar variant is tagged as $version-sidecar e.g. buildkite/agent:3-sidecar.
 
 Adding the agent sidecar to your task definition can be handled by the
 [CloudFormation Macro](#buildkite-agent-cloudformation-macro).
@@ -174,7 +173,7 @@ Ruby2:
   Type: Buildkite::ECS::TaskDefinition
   Properties:
     Image: ruby:2.7
-    BuildkiteAgentImage: keithduncan/buildkite-sidecar:latest
+    BuildkiteAgentImage: buildkite/agent:3-sidecar
     TaskFamily: ruby2
     TaskCpu: 1024
     TaskMemory: 2048
@@ -184,7 +183,7 @@ This creates a task definition called `ruby2`, which you would address in your
 on-demand pipeline with a `task-definition: ruby2` Agent Query Rule.
 
 The main image is `ruby:2.7` from Docker Hub, the Buildkite sidecar is
-`keithduncan/buildkite-sidecar:latest`.
+`buildkite/agent:3-sidecar`.
 
 This image doesn't have an `iam-ssh-agent` sidecar and so cannot clone private
 repositories.
@@ -330,15 +329,15 @@ Resources:
   Buildkite:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
-      Image: keithduncan/buildkite-base
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar
+      Image: buildkite/on-demand-base
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       TaskFamily: buildkite
       TaskCpu: 256
       TaskMemory: 512
 ```
 
-This task definition uses a [base image](https://github.com/buildkite/buildkite-base)
-and [agent sidecar image](https://github.com/buildkite/buildkite-sidecar)
+This task definition uses a [base image](https://github.com/buildkite/on-demand-base)
+and [agent sidecar image](https://github.com/buildkite/agent/tree/master/packaging/docker/sidecar)
 from Docker Hub. You can of course use your own base image with your own set
 of pre-installed software. Avoid installing too much in your base image, prefer
 to use more specific task definitions with their own image to avoid collisions
@@ -374,7 +373,7 @@ Resources:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
       Image: ruby:2.7.0
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       TaskFamily: ruby2
       TaskCpu: 1024
       TaskMemory: 2048
@@ -417,15 +416,15 @@ Resources:
     Properties:
       TemplateURL: examples/kaniko/kaniko.yml
       Parameters:
-        Image: keithduncan/buildkite-base
-        BuildkiteAgentImage: keithduncan/buildkite-sidecar
+        Image: buildkite/on-demand-base
+        BuildkiteAgentImage: buildkite/agent:3-sidecar
         DockerConfigAwsRegistriesEcrHelper:
           !Join
             - ","
             - [ !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com" ]
 ```
 
-`keithduncan/buildkite-base` includes `socat` which is needed to communicate
+`buildkite/on-demand-base` includes `socat` which is needed to communicate
 with the kaniko sidecar container.
 
 This instantiation of the kaniko stack configures kaniko to use `ecr-login` when
@@ -499,7 +498,7 @@ Adding the `iam-ssh-agent` sidecar to the Ruby task definition would like this:
      Type: Buildkite::ECS::TaskDefinition
      Properties:
        Image: ruby:2.7.0
-       BuildkiteAgentImage: keithduncan/buildkite-sidecar
+       BuildkiteAgentImage: buildkite/agent:3-sidecar
 +      SshAgentBackend: arn:aws:execute-api:us-east-1:12345EXAMPLE:zEXAMPLE12/Prod
        TaskFamily: ruby2
        TaskCpu: 1024

--- a/agent-composer/examples/kaniko/README.md
+++ b/agent-composer/examples/kaniko/README.md
@@ -8,7 +8,8 @@ daemon.
 
 ## Template Parameters
 
-* **Image**: Main image, must include `socat`. See [buildkite/buildkite-base](https://github.com/buildkite/buildkite-base/blob/master/agent/Dockerfile) for an example.
+* **Image**: Main image, must include `socat`. See [buildkite/on-demand-base](https://github.com/buildkite/on-demand-base/blob/master/agent/Dockerfile)
+for an example.
 * **BuildkiteAgentImage**: Buildkite Agent sidecar image.
 * **BuildkiteAgentTokenParameterPath**: Optional, The AWS SSM Parameter Store parameter
 path to a Buildkite Agent registration token. Defaults to `/buildkite/agent-token`.

--- a/agent-composer/examples/kaniko/kaniko.yml
+++ b/agent-composer/examples/kaniko/kaniko.yml
@@ -8,7 +8,7 @@ Parameters:
     Description: Base image the `agent` container will execute the Buildkite Agent in, requires socat or another tool to communicate with the kaniko daemon.
   BuildkiteAgentImage:
     Type: String
-    Description: Sidecar image for the `agent-init` container, e.g. keithduncan/buildkite-sidecar.
+    Description: Sidecar image for the `agent-init` container, e.g. buildkite/agent:3-sidecar.
     # AllowedPattern: "^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*((\:[\\w\\-_\.]+)|(@[\\w\\-_]+:\\w+)){0,1}$"
     ConstraintDescription: |
       must be a Docker image reference e.g. node:12, buildkite/agent:latest, 012345678910.dkr.ecr.us-east-1.amazonaws.com/agent/buildkite:latest, quay.io/organization/image, keithduncan/agent@sha256:94afd1f2e64d908bc90dbca0035a5b567EXAMPLE

--- a/agent-composer/examples/template.yml
+++ b/agent-composer/examples/template.yml
@@ -43,8 +43,8 @@ Resources:
   Buildkite:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
-      Image: keithduncan/buildkite-base:latest
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar:latest
+      Image: buildkite/on-demand-base:latest
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       SshAgentBackend: !Ref SshAgentBackend
       TaskFamily: buildkite
 
@@ -67,7 +67,7 @@ Resources:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
       Image: ruby:2.7.0
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar:latest
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       SshAgentBackend: !Ref SshAgentBackend
       TaskFamily: ruby2
 
@@ -82,7 +82,7 @@ Resources:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
       Image: hashicorp/terraform:light
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar:latest
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       SshAgentBackend: !Ref SshAgentBackend
       TaskFamily: terraform
 
@@ -100,8 +100,8 @@ Resources:
     Properties:
       TemplateURL: kaniko/kaniko.yml
       Parameters:
-        Image: keithduncan/buildkite-base:latest
-        BuildkiteAgentImage: keithduncan/buildkite-sidecar:latest
+        Image: buildkite/on-demand-base:latest
+        BuildkiteAgentImage: buildkite/agent:3-sidecar
         SshAgentBackend:
           !If
             - HasSshAgentBackend
@@ -139,7 +139,7 @@ Resources:
     Type: Buildkite::ECS::TaskDefinition
     Properties:
       Image: !GetAtt BuildSam.Outputs.Image
-      BuildkiteAgentImage: keithduncan/buildkite-sidecar
+      BuildkiteAgentImage: buildkite/agent:3-sidecar
       SshAgentBackend: !Ref SshAgentBackend
       TaskFamily: sam
       Environment:

--- a/agent-scheduler/src/handlers/buildkite-run-task.js
+++ b/agent-scheduler/src/handlers/buildkite-run-task.js
@@ -201,7 +201,7 @@ async function getEcsRunTaskParamsForJob(cluster, job) {
                 containerDefinitions: [
                     {
                         name: "agent-init",
-                        image: "keithduncan/buildkite-sidecar",
+                        image: "buildkite/agent:3-sidecar",
                         essential: false,
                         entryPoint: [
                             '/bin/sh',


### PR DESCRIPTION
These are all moved to Buildkite owned organisations now.

Depends on https://github.com/buildkite/agent/pull/1218
Depends on https://github.com/buildkite/on-demand-template/pull/3